### PR TITLE
Alert assets page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,9 +3,6 @@ baseurl: /pages/CMSGov/cmsgov.github.io
 permalink: /:categories/:title
 markdown: rdiscount
 highlighter: null
-syntax-highlighting:
-  enabled : true
-  css: syntax.css
 encoding: utf-8
 #exclude : ['sass', 'config.rb', 'README.md']
 exclude:

--- a/_includes/css/detail-page.less
+++ b/_includes/css/detail-page.less
@@ -54,6 +54,10 @@
 			margin-right: 0px;
 		}
 
+		.alert > p {
+			color: #FFF;
+		}
+
 		#secondary-alert .hero-message {
 			padding: 25px;	
 			padding-bottom: 30px;

--- a/css/style.css
+++ b/css/style.css
@@ -7175,6 +7175,9 @@ a[name="skipnav"] {
   margin-left: 0px;
   margin-right: 0px;
 }
+#detail-page #hc-gov-assets .alert > p {
+  color: #FFF;
+}
 #detail-page #hc-gov-assets #secondary-alert .hero-message {
   padding: 25px;
   padding-bottom: 30px;


### PR DESCRIPTION
This pull request resolves https://jira.cms.gov/browse/WDSG-62 by inserting the content for the alerts page of the assets section.
- Styling was updated to match what was on the old styleguide as well as styles from hc.gov for the secondary alert (note, I thought it looked better and is less restrictive/more helpful for developers to not put in all the bootstrap grid classes for the secondary alert.  Developers should know enough to put in their own grid classes if they would like.
- Additionally, I converted the code snippets in the markdown page to markdown. This increases the readability of the markdown file for future content updates so html is not using &gt or &lt in the markdown.

TODO: 
- convert other code snippets in the markdown to use markdown formatting
- see what other hard coded HTML can be formatted with markdown to improve readability/content update usability.  That could be more troublesome to update, but may want to look into for future version.
