### PR TITLE
Small Fix for IE8 and Zero Clipboard

### DIFF
--- a/_includes/sub-navigation.html
+++ b/_includes/sub-navigation.html
@@ -40,8 +40,8 @@
 
 			{% comment %}<!-- Cleanup if last link was inside subcategory -->{% endcomment %}
 			{% if subNav == true%}
-					</li>
-				</ul>
+					</ul>
+				</li>
 			{% endif %}
 		</ul>
 	</div>

--- a/js/main.js
+++ b/js/main.js
@@ -39,9 +39,7 @@ $(document).ready(function() {
   // Attach mobile flyout click command
   $('.mobile-menu-btn').on('click.show', showMobileNav);
 
-  if (isIE() < 9) {
-
-  } else{
+  if(!isIE() || (isIE() > 8)){
     // Zero Clipboard
     var clip = new ZeroClipboard($(".copy-button"));
 


### PR DESCRIPTION
I had the last fix needed to get ZeroClipboard - IE8 fix working, but somehow sent up the second to last version.

Checked chrome and IE10 (has zero clipboard)
Checked IE8, no clipboard (expected behavior, not supported in IE8)
