### PR TITLE
added aria-describedby functionality to assets text popover code and …

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -22,6 +22,7 @@
   <script src="{{site.baseurl}}/js/main.js"></script>
   <script src="{{site.baseurl}}/js/faqs.js"></script>
   <script src="{{site.baseurl}}/assets-components/js/bootstrap-accessibility.min.js"></script>
+  <script src="{{site.baseurl}}/assets-components/js/main.js"></script>
 
   <link rel="stylesheet" type="text/css" href="{{site.baseurl}}/assets-components/css/style.css" />
   <link rel="stylesheet" href="{{site.baseurl}}/assets-components/css/bootstrap-accessibility.css" />

--- a/_posts/assets/0001-01-01-text.md
+++ b/_posts/assets/0001-01-01-text.md
@@ -177,29 +177,14 @@ Popovers are used to define terms or program names that consumers might not be f
 
 <div class="code-wrapper">
 <div class="preview">
-	<p>An example of a popover <a tabindex="0" role="button" href="javascript:;" class="glossary-term help-popover" aria-describedby="glossary-data-tooltip" data-placement="bottom" data-toggle="popover" data-trigger="hover focus" data-title="Minimum value" data-content="A health plan meets this standard if it’s designed to pay at least 60% of the total cost of medical services for a standard population. Starting in 2014, individuals offered employer-sponsored coverage that provides minimum value and that’s affordable won’t be eligible for a premium tax credit.">minimum requirements</a>.</p>
+	<p>An example of a popover <a href="#" role="button" class="glossary-term help-popover" data-title="Minimum value" data-content="A health plan meets this standard if it’s designed to pay at least 60% of the total cost of medical services for a standard population. Starting in 2014, individuals offered employer-sponsored coverage that provides minimum value and that’s affordable won’t be eligible for a premium tax credit.">minimum requirements</a>.</p>
 </div>
-<script type="text/javascript">
-  $(".glossary-term").popover();
-</script>
 <pre>
-<code id="popover-code">&lta tabindex="0" role="button" href="javascript:;" class="glossary-term help-popover" aria-describedby="glossary-data-tooltip" data-placement="bottom" data-toggle="popover" data-trigger="hover focus" data-title="Popover title" data-content="Popover content"&gtExample popovers&lt/a&gt
+<code id="popover-code">&lta role="button" href="#" class="glossary-term help-popover" data-title="Popover title" data-content="Popover content"&gtExample popover&lt/a&gt
 </code>
 </pre>
 <a href="javascript:;" class="copy-button" title="Click to copy me." data-clipboard-target="popover-code" role="button">Copy</a>
 </div>
-
-<div class="code-wrapper">
-<pre>
-<code id="popover-js-code">
-&ltscript type="text/javascript"&gt
-$(".glossary-term").popover();
-&lt/script&gt
-</code>
-</pre>
-	<a href="javascript:;" class="copy-button" title="Click to copy me." data-clipboard-target="popover-js-code" role="button">Copy</a>
-</div>
-
 
 * * *
 

--- a/_posts/assets/0001-01-08-skip-to-results.md
+++ b/_posts/assets/0001-01-08-skip-to-results.md
@@ -64,7 +64,7 @@ This version of the skip to results module includes a progress indicator to show
 			<div class="notification-box">
 				<div>
 
-					<p><strong><a tabindex="0" role="button" class="tip" aria-hidden="true" href="#" data-toggle="tooltip" data-placement="left" data-trigger="hover focus" title="" target="_self" data-original-title="If you go to plan results without answering these questions the cost estimates for the plans you’ll see won’t include the cost savings you might qualify for like a premium tax credit. Also the plan results won’t be specific to you and your household. You’ll see plans for a single person age 35 and a non-parent."><span class="glyphicon glyphicon-info-sign" aria-label="information"></span> <span data-ng-bind="progress" class="ng-binding">50</span>% of questions answered</a></strong></p>
+					<p><strong><a tabindex="0" role="button" class="tip" data-placement="left" title="If you go to plan results without answering these questions the cost estimates for the plans you’ll see won’t include the cost savings you might qualify for like a premium tax credit. Also the plan results won’t be specific to you and your household. You’ll see plans for a single person age 35 and a non-parent."><span class="glyphicon glyphicon-info-sign" aria-label="information"></span> 50% of questions answered</a></strong></p>
 
 					<p>Select See plans now to view plans in your area.</p>
 
@@ -81,7 +81,7 @@ This version of the skip to results module includes a progress indicator to show
 		<div class="notification-box">
 			<div>
 
-				<p><strong><a tabindex="0" role="button" class="tip" aria-hidden="true" href="#" data-toggle="tooltip" data-placement="left" data-trigger="hover focus" title="" target="_self" data-original-title="If you go to plan results without answering these questions the cost estimates for the plans you’ll see won’t include the cost savings you might qualify for like a premium tax credit. Also the plan results won’t be specific to you and your household. You’ll see plans for a single person age 35 and a non-parent."><span class="glyphicon glyphicon-info-sign" aria-label="information"></span> <span data-ng-bind="progress" class="ng-binding">50</span>% of questions answered</a></strong></p>
+				<p><strong><a tabindex="0" role="button" class="tip" data-placement="left" title="If you go to plan results without answering these questions the cost estimates for the plans you’ll see won’t include the cost savings you might qualify for like a premium tax credit. Also the plan results won’t be specific to you and your household. You’ll see plans for a single person age 35 and a non-parent."><span class="glyphicon glyphicon-info-sign" aria-label="information"></span> 50% of questions answered</a></strong></p>
 
 				<p>Select See plans now to view plans in your area.</p>
 
@@ -91,15 +91,4 @@ This version of the skip to results module includes a progress indicator to show
 		{% endhighlight %}
 	</div>
 	<a href="javascript:;" class="copy-button" title="Click to copy me." data-clipboard-target="skip-to-results-progress-code" role="button">Copy</a>
-</div>
-
-<div class="code-wrapper">
-	<div id="tooltip-js-code">
-{% highlight text %}
-<script type="text/javascript">
-	$(".tip").tooltip();
-</script>
-{% endhighlight %}
-	</div>
-	<a href="javascript:;" class="copy-button" title="Click to copy me." data-clipboard-target="tooltip-js-code" role="button">Copy</a>
 </div>

--- a/assets-components/js/main.js
+++ b/assets-components/js/main.js
@@ -82,30 +82,6 @@ $(function() {
 // Glossary Terms
 gov.hc.glossaryTerms = {
   options_tooltip : {
-    placement: function (context, source) {
-      var position = $(source).offset();
-      var rtOffset = ($(window).width() - ($(source).offset().left + $(source).outerWidth()));
-      var lftOffset = (position.left - $(window).scrollLeft());
-      var topOffset = (position.top - $(window).scrollTop());
-      var bottomOffset = ($(window).height() - topOffset);
-
-      if (rtOffset > lftOffset) {
-          if (topOffset < 300) {
-              return "bottom";
-          } else if (bottomOffset < 300) {
-              return "top";
-          }
-          return "right";
-      }
-      else {
-          if (topOffset < 300) {
-              return "bottom";
-          } else if (bottomOffset < 300) {
-              return "top";
-          }
-          return "left";
-      }
-    },
     trigger: "hover focus",
     container: "#hc-gov-assets"
   },
@@ -113,20 +89,53 @@ gov.hc.glossaryTerms = {
 
     $(terms).each(function(){
         var uid = gov.hc.util.getUID('tooltip'), //Polyfill
-            className = 'popover',
+            className = '',
+            tooltipTemplate = '<div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>',
+            popoverTemplate = '<div class="arrow"></div><h3 class="popover-title"></h3><div class="popover-content"></div></div>',
             $this = $(this);
-        if(this.className.indexOf('tooltip') !== -1){
-            className += ' fade left';
-            $this.attr('aria-label','tooltip');
+        
+        $this.attr({'aria-describedby': uid});
+
+        // Polyfill 
+        if(this.className.indexOf('tip') !== -1){
+          
+            className += 'left tooltip';
+            gov.hc.glossaryTerms.options_tooltip.template = '<div aria-role="tooltip" class="'+ className + '" id="' + uid + '">' + tooltipTemplate;
+            
+            $(this).tooltip(gov.hc.glossaryTerms.options_tooltip);
+
         } else {
-            className += ' popover-glossary';
+            
+            className += 'popover popover-glossary';
+            gov.hc.glossaryTerms.options_tooltip.template = '<div aria-role="tooltip" class="'+ className + '" id="' + uid + '">' + popoverTemplate;
+            gov.hc.glossaryTerms.options_tooltip.placement = function (context, source) {
+              var position = $(source).offset();
+              var rtOffset = ($(window).width() - ($(source).offset().left + $(source).outerWidth()));
+              var lftOffset = (position.left - $(window).scrollLeft());
+              var topOffset = (position.top - $(window).scrollTop());
+              var bottomOffset = ($(window).height() - topOffset);
+
+              if (rtOffset > lftOffset) {
+                  if (topOffset < 300) {
+                      return "bottom";
+                  } else if (bottomOffset < 300) {
+                      return "top";
+                  }
+                  return "right";
+              }
+              else {
+                  if (topOffset < 300) {
+                      return "bottom";
+                  } else if (bottomOffset < 300) {
+                      return "top";
+                  }
+                  return "left";
+              };
+            }
+            
+          $(this).popover(gov.hc.glossaryTerms.options_tooltip);
+
         }
-        // Polyfill
-        gov.hc.glossaryTerms.options_tooltip.template = '<div aria-role="tooltip" class="'+ className + '" id="' + uid + '"><div class="arrow"></div><h3 class="popover-title"></h3><div class="popover-content"></div></div>';
-        $this.attr({
-                'aria-describedby': uid
-              })
-              .popover(gov.hc.glossaryTerms.options_tooltip);
 
         // prevent link from firing natural event
         // and appending a "#" to the url.
@@ -148,4 +157,5 @@ gov.hc.glossaryTerms = {
 
 $(function() {
   gov.hc.glossaryTerms.setAria(".glossary-term");
+  gov.hc.glossaryTerms.setAria(".tip");
 })

--- a/assets-components/js/main.js
+++ b/assets-components/js/main.js
@@ -1,47 +1,22 @@
-// Sidr Navigation
+var gov = gov || {};
+gov.hc = gov.hc || {};
 
-$(function() {
-
-  // Attach mobile flyout click command
-  $('.mobile-menu-btn').on('click.show', showMobileNav);
-
-});
-
-var showMobileNav = function(e) {
-  if (e) {
-    e.preventDefault();
+// Utility functions
+gov.hc.util = {
+  getUID : function (identifier) {
+      return identifier + ~~(Math.random() * 1000000);
   }
-
-  $('.mobile-menu-btn').off('click.show');
-
-  $('#wrapper').addClass('pushed');
-
-  var $nav = $('#sidr');
-  $nav.addClass('visible');
-
-  _.defer(function() {
-    $(document.body).on('click.mobilenav', function(e) {
-
-      if (!$.contains($nav[0], e.target) && !$nav.is($(e.target))) {
-        hideMobileNav();
-        $nav = null;
-      }
-    });
-  });
 };
 
+// Sidr Navigation
+gov.hc.sidr = {
+  init: function() {
+    
+    // Attach mobile flyout click command
+    $('#hc-gov-assets .mobile-menu-btn').on('click.show', gov.hc.sidr.showMobileNav);
 
-var hideMobileNav = function() {
-  $('#wrapper').removeClass('pushed');
-  $('#sidr').removeClass('visible');
-
-  $(document.body).off('click.mobilenav');
-  $('.mobile-menu-btn').on('click.show', showMobileNav);
-};
-
-$(function(){
-
-    $('#sidr .header-actions a').click(function (e) {
+    // on click, update section colors
+    $('#hc-gov-assets #sidr .header-actions a').click(function (e) {
       
       e.preventDefault();
 
@@ -63,8 +38,114 @@ $(function(){
 
         }
 
-      $('#sidr').attr("class",css);
+      $('#hc-gov-assets #sidr').attr("class",css);
 
     });
+  },
+  showMobileNav: function(e) {
 
+    if (e) {
+      e.preventDefault();
+    }
+
+    $('#hc-gov-assets .mobile-menu-btn').off('click.show');
+
+    $('#hc-gov-assets #wrapper').addClass('pushed');
+
+    var $nav = $('#hc-gov-assets #sidr');
+    $nav.addClass('visible');
+
+    _.defer(function() {
+      $(document.body).on('click.mobilenav', function(e) {
+
+        if (!$.contains($nav[0], e.target) && !$nav.is($(e.target))) {
+          gov.hc.sidr.hideMobileNav();
+          $nav = null;
+        }
+      });
+    });
+
+  },
+  hideMobileNav: function() {
+    $('#hc-gov-assets #wrapper').removeClass('pushed');
+    $('#hc-gov-assets #sidr').removeClass('visible');
+
+    $(document.body).off('click.mobilenav');
+    $('#hc-gov-assets .mobile-menu-btn').on('click.show', gov.hc.sidr.showMobileNav);
+  }
+};
+
+$(function() {
+  gov.hc.sidr.init();
+});
+
+// Glossary Terms
+gov.hc.glossaryTerms = {
+  options_tooltip : {
+    placement: function (context, source) {
+      var position = $(source).offset();
+      var rtOffset = ($(window).width() - ($(source).offset().left + $(source).outerWidth()));
+      var lftOffset = (position.left - $(window).scrollLeft());
+      var topOffset = (position.top - $(window).scrollTop());
+      var bottomOffset = ($(window).height() - topOffset);
+
+      if (rtOffset > lftOffset) {
+          if (topOffset < 300) {
+              return "bottom";
+          } else if (bottomOffset < 300) {
+              return "top";
+          }
+          return "right";
+      }
+      else {
+          if (topOffset < 300) {
+              return "bottom";
+          } else if (bottomOffset < 300) {
+              return "top";
+          }
+          return "left";
+      }
+    },
+    trigger: "hover focus",
+    container: "#hc-gov-assets"
+  },
+  setAria: function(terms) {
+
+    $(terms).each(function(){
+        var uid = gov.hc.util.getUID('tooltip'), //Polyfill
+            className = 'popover',
+            $this = $(this);
+        if(this.className.indexOf('tooltip') !== -1){
+            className += ' fade left';
+            $this.attr('aria-label','tooltip');
+        } else {
+            className += ' popover-glossary';
+        }
+        // Polyfill
+        gov.hc.glossaryTerms.options_tooltip.template = '<div aria-role="tooltip" class="'+ className + '" id="' + uid + '"><div class="arrow"></div><h3 class="popover-title"></h3><div class="popover-content"></div></div>';
+        $this.attr({
+                'aria-describedby': uid
+              })
+              .popover(gov.hc.glossaryTerms.options_tooltip);
+
+        // prevent link from firing natural event
+        // and appending a "#" to the url.
+        $this.click(function(event){
+            event.preventDefault();
+        });
+        // for keyboard users - enter key prevent
+        // link from firing natural event.
+        // and appending a "#" to the url.
+        $this.keypress(function(event) {
+            if(event.which == '13') {
+                event.preventDefault();
+            }
+        });
+    });
+
+  }  
+};
+
+$(function() {
+  gov.hc.glossaryTerms.setAria(".glossary-term");
 })

--- a/js/main.js
+++ b/js/main.js
@@ -1,101 +1,141 @@
-// Show mobile flyout navigation
-var showMobileNav = function(e) {
-  if (e) {
-    e.preventDefault();
-  }
+var gov = gov || {};
+gov.hc = gov.hc || {};
+gov.hc.sg = gov.hc.sg || {};
 
-  $('.mobile-menu-btn').off('click.show');
-
-  $('#wrapper').addClass('pushed');
-
-  var $nav = $('#sidr');
-  $nav.addClass('visible');
-
-  _.defer(function() {
-    $(document.body).on('click.mobilenav', function(e) {
-      if (!$.contains($nav[0], e.target) && !$nav.is($(e.target))) {
-        hideMobileNav();
-        $nav = null;
-      }
-    });
-  });
+// Utils
+gov.hc.sg.utils = {
+  isIE: function() {
+      var myNav = navigator.userAgent.toLowerCase();
+      return (myNav.indexOf('msie') != -1) ? parseInt(myNav.split('msie')[1]) : false;
+    }
 };
 
-// Hide mobile flyout navigation
-var hideMobileNav = function() {
-  $('#wrapper').removeClass('pushed');
-  $('#sidr').removeClass('visible');
+// Styleguide Mobile Navigation
+gov.hc.sg.sidr = {
+  init: function() {
 
-  $(document.body).off('click.mobilenav');
-  $('.mobile-menu-btn').on('click.show', showMobileNav);
+    // Attach mobile flyout click command
+    $('.mobile-menu-btn').on('click.show', gov.hc.sg.sidr.showMobileNav);
+
+  },
+  showMobileNav: function(e) {
+    
+    if (e) {
+      e.preventDefault();
+    }
+
+    $('.mobile-menu-btn').off('click.show');
+
+    $('#wrapper').addClass('pushed');
+
+    var $nav = $('#sidr');
+    $nav.addClass('visible');
+
+    _.defer(function() {
+      $(document.body).on('click.mobilenav', function(e) {
+        if (!$.contains($nav[0], e.target) && !$nav.is($(e.target))) {
+          gov.hc.sg.sidr.hideMobileNav();
+          $nav = null;
+        }
+      });
+    });
+
+  },
+  hideMobileNav: function() {
+
+    $('#wrapper').removeClass('pushed');
+    $('#sidr').removeClass('visible');
+
+    $(document.body).off('click.mobilenav');
+    $('.mobile-menu-btn').on('click.show', gov.hc.sg.sidr.showMobileNav);
+
+  }
 };
 
-function isIE () {
-  var myNav = navigator.userAgent.toLowerCase();
-  return (myNav.indexOf('msie') != -1) ? parseInt(myNav.split('msie')[1]) : false;
-}
-
-$(document).ready(function() {
-  // Attach mobile flyout click command
-  $('.mobile-menu-btn').on('click.show', showMobileNav);
-
-  if(!isIE() || (isIE() > 8)){
-    // Zero Clipboard
-    var clip = new ZeroClipboard($(".copy-button"));
-
-      clip.on("ready", function() {
-        //console.log("Flash movie loaded and ready.");
-
-        this.on("aftercopy", function(event) {
-          //console.log("Copied text to clipboard: " + event.data["text/plain"]);
-        });
-    });
-
-    clip.on("error", function(event) {
-      $(".demo-area").hide();
-      console.log('error[name="' + event.name + '"]: ' + event.message);
-      ZeroClipboard.destroy();
-    });
-  }
+$(function() {
+  gov.hc.sg.sidr.init();
 });
 
-$(document).ready(function() {
+// Zero Clipboard
+gov.hc.sg.zeroclipboard = {
+  init: function() {
 
-  // Toggle submenu in interior navigation
-  $('.toggle-interior-nav').click(function(){
-    $(this).toggleClass('closed');
-    var ul = $(this).siblings('ul');
-    ul.toggle();
-    var ariaHiddenBoolean = true;
-    var chevron = $(this).siblings('.glyphicon');
+    if(!gov.hc.sg.utils.isIE() || (gov.hc.sg.utils.isIE() > 8)){
+      // Zero Clipboard
+      var clip = new ZeroClipboard($(".copy-button"));
 
-    if(chevron.hasClass('glyphicon-chevron-right')){
-      chevron.removeClass('glyphicon-chevron-right');
-      chevron.addClass('glyphicon-chevron-down');
-      ariaHiddenBoolean = false;
-    
-    } else{
-      chevron.removeClass('glyphicon-chevron-down');
-      chevron.addClass('glyphicon-chevron-right');
+        clip.on("ready", function() {
+          //console.log("Flash movie loaded and ready.");
+
+          this.on("aftercopy", function(event) {
+            //console.log("Copied text to clipboard: " + event.data["text/plain"]);
+          });
+      });
+
+      clip.on("error", function(event) {
+        $(".demo-area").hide();
+        console.log('error[name="' + event.name + '"]: ' + event.message);
+        ZeroClipboard.destroy();
+      });
+    };
+
+  }
+};
+
+$(function() {
+  gov.hc.sg.zeroclipboard.init();
+});
+
+// Interior Left Navigation
+gov.hc.sg.interiorNav = {
+  init: function() {
+ 
+    // Toggle submenu in interior navigation
+    $('.toggle-interior-nav').click(function(){
+      $(this).toggleClass('closed');
+      var ul = $(this).siblings('ul');
+      ul.toggle();
+      var ariaHiddenBoolean = true;
+      var chevron = $(this).siblings('.glyphicon');
+
+      if(chevron.hasClass('glyphicon-chevron-right')){
+        chevron.removeClass('glyphicon-chevron-right');
+        chevron.addClass('glyphicon-chevron-down');
+        ariaHiddenBoolean = false;
       
-    }
-    
-    ul.attr("aria-hidden", ariaHiddenBoolean);
-  });
+      } else{
+        chevron.removeClass('glyphicon-chevron-down');
+        chevron.addClass('glyphicon-chevron-right');
+        
+      }
+      
+      ul.attr("aria-hidden", ariaHiddenBoolean);
 
-  if($("#landing-page").length > 0) {
-    
-    $(window).scroll(function() {
-      var subnav = $(".subnav-wrapper");
-      var y = Math.floor(subnav[0].getBoundingClientRect().top) - $(window).scrollTop();
-
-      if (y < 0)
-          subnav.addClass("fixed-nav");
-      else
-          subnav.removeClass("fixed-nav");
     });
 
-  } else if($("#detail-page").length > 0)
-    $("#detail-page .subnav-wrapper").addClass("fixed-nav");
+    gov.hc.sg.interiorNav.fixToTop();
+  },
+  fixToTop: function() {
 
+    // fix to top of page
+    if($("#landing-page").length > 0) {
+      
+      $(window).scroll(function() {
+        var subnav = $(".subnav-wrapper");
+        var y = Math.floor(subnav[0].getBoundingClientRect().top) - $(window).scrollTop();
+
+        if (y < 0)
+            subnav.addClass("fixed-nav");
+        else
+            subnav.removeClass("fixed-nav");
+
+      });
+
+    } else if($("#detail-page").length > 0)
+      $("#detail-page .subnav-wrapper").addClass("fixed-nav");
+  }
+};
+
+$(function() {
+  gov.hc.sg.interiorNav.init();
 });


### PR DESCRIPTION
…revised structure of javascript in both the assets framework and the styleguide site.

This pull-request contains updates to assets-components/js/main.js AND js/main.js. This was needed to get the aria functionality working correctly on the glossary terms popover. You'll see updates throughout the javascript files because I needed to add namespaced closures to the code to make sure  the global namespaces for the styleguide site, in addition to the assets framework, would not get polluted and cause clashing code between the two when javascript from the assets framework is pulled into the styleguide site.