### PR TITLE
fixed h3 sizing on detail and landing pages

### DIFF
--- a/_includes/css/commonstyles.less
+++ b/_includes/css/commonstyles.less
@@ -235,6 +235,10 @@ a[name="skipnav"] {padding:0;margin: 0;display:block; border:none;}
 		margin-bottom:10px;
 	}
 
+	h3 {
+		font-size:20px;
+	}
+
 	.code-wrapper pre{
 		font-size:15px;
 	}

--- a/css/style.css
+++ b/css/style.css
@@ -6906,6 +6906,10 @@ a[name="skipnav"] {
   margin-top: 20px;
   margin-bottom: 10px;
 }
+#landing-page h3,
+#detail-page h3 {
+  font-size: 20px;
+}
 #landing-page .code-wrapper pre,
 #detail-page .code-wrapper pre {
   font-size: 15px;


### PR DESCRIPTION
this fixes the governance page h3 sizing being bigger than the h2 sizing.
