### PR TITLE
added bower installation package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,43 @@
+{
+  "name": "healthCare.gov-styleguide",
+  "version": "1.0.0",
+  "homepage": "https://github.com/CMSgov/HealthCare.gov-Styleguide",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/CMSgov/HealthCare.gov-Styleguide.git"
+  },
+  "authors": [
+    "Centers for Medicare & Medicaid Services"
+  ],
+  "description": "Healthcare.gov Styleguide Assets Components",
+  "main": [
+    "assets-components/css/all.less"
+  ],
+  "keywords": [
+    "less"
+  ],
+  "license": "MIT",
+  "private": true,
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests",
+    "_includes",
+    "_layouts",
+    "_posts",
+    "_site",
+    "css",
+    "downloads",
+    "fonts",
+    "images",
+    "js",
+    "libary",
+    ".*"
+  ],
+  "dependencies": {
+    "grunt": "~0.4.5",
+    "grunt-contrib-less": "~1.0.1"
+  }
+}


### PR DESCRIPTION
added bower installation package. Please note, this package is deliberately set to "private" so that it is not accidentally registered to the public bower registry. Once we are given permission to publish the bower package, we will have to remove this setting, and then register the package via the following settings:

http://bower.io/docs/creating-packages/#register
